### PR TITLE
add var for cross zone load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ cp terraform.tfvars.example terraform.tfvars
 | mz_rds_vpc_id | The VPC ID of the RDS instance | string | `'vpc-1234567890abcdef0'` | yes |
 | mz_acceptance_required | Whether or not to require manual acceptance of new connections | bool | `true` | no |
 | schedule_expression | [The scheduling expression](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#schedule_expression). For example, `cron(0 20 * * ? *)` | string | `'rate(5 minutes)'` | no |
+| cross_zone_load_balancing | Enables cross zone load balancing for the NLB | bool | `no` | no |
 
 ### Apply the Terraform Module
 

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "aws_lb" "mz_rds_lb" {
   name               = "mz-rds-${substr(var.mz_rds_instance_name, 0, 12)}-lb"
   internal           = true
   load_balancer_type = "network"
+  enable_cross_zone_load_balancing = var.cross_zone_load_balancing
   subnets            = values(data.aws_subnet.mz_rds_subnet)[*].id
   tags = {
     Name = "mz-rds-lb"

--- a/variables.tf
+++ b/variables.tf
@@ -30,3 +30,10 @@ variable "schedule_expression" {
   type        = string
   default     = "rate(5 minutes)"
 }
+
+# Enable cross zone load balancing
+variable "cross_zone_load_balancing" {
+  description = "Enables cross zone load balancing for the NLB"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
I believe if we're specifying multiple subnets for the NLB and multiple availability zones for the mz privatelink connection, but there is only one RDS instance we will need cross zone load balancing enabled.